### PR TITLE
replace gx instructions with note about gomod

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,12 @@ Note: This package largely replaces the functionality of [go-libp2p-conn](https:
 go get github.com/libp2p/go-libp2p-transport-upgrader
 ```
 
-Note that `go-libp2p-transport-upgrader` is packaged with Gx, so it is recommended to use Gx to install and use it (see the Usage section).
+This repo is [gomod](https://github.com/golang/go/wiki/Modules)-compatible, and users of
+go 1.11 and later with modules enabled will automatically pull the latest tagged release
+by referencing this package. Upgrades to future releases can be managed using `go get`,
+or by editing your `go.mod` file as [described by the gomod documentation](https://github.com/golang/go/wiki/Modules#how-to-upgrade-and-downgrade-dependencies).
 
 ## Usage
-
-This module is packaged with [Gx](https://github.com/whyrusleeping/gx). In order to use it in your own project it is recommended that you:
-
-```sh
-go get -u github.com/whyrusleeping/gx
-go get -u github.com/whyrusleeping/gx-go
-cd <your-project-repository>
-gx init
-gx import github.com/libp2p/go-libp2p-transport-upgrader
-gx install --global
-gx-go --rewrite
-```
-
-Please check [Gx](https://github.com/whyrusleeping/gx) and [Gx-go](https://github.com/whyrusleeping/gx-go) documentation for more information.
 
 ## Example
 


### PR DESCRIPTION
relevant to https://github.com/libp2p/go-libp2p/issues/589, this removes the gx instructions with a little blurb about gomod.