### PR TITLE
fix an incorrect error message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,5 @@ require (
 	github.com/onsi/ginkgo v1.8.0
 	github.com/onsi/gomega v1.5.0
 )
+
+go 1.12

--- a/upgrader.go
+++ b/upgrader.go
@@ -91,7 +91,7 @@ func (u *Upgrader) upgrade(ctx context.Context, t transport.Transport, maconn ma
 	smconn, err := u.setupMuxer(ctx, sconn, p)
 	if err != nil {
 		sconn.Close()
-		return nil, fmt.Errorf("failed to negotiate security stream multiplexer: %s", err)
+		return nil, fmt.Errorf("failed to negotiate stream multiplexer: %s", err)
 	}
 	return &transportConn{
 		MuxedConn:      smconn,


### PR DESCRIPTION
"security stream multiplexer" is the worst sort of confusing.