### PR TITLE
make it possible to skip the handshake negotiation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.16
 require (
 	github.com/ipfs/go-log v1.0.4
 	github.com/jbenet/go-temp-err-catcher v0.1.0
-	github.com/libp2p/go-libp2p-core v0.10.0
+	github.com/libp2p/go-libp2p-core v0.10.1-0.20210921170543-f829c09c1ca0
 	github.com/libp2p/go-libp2p-mplex v0.4.1
 	github.com/libp2p/go-libp2p-pnet v0.2.0
-	github.com/multiformats/go-multiaddr v0.3.3
+	github.com/multiformats/go-multiaddr v0.4.1
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/libp2p/go-flow-metrics v0.0.3/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS
 github.com/libp2p/go-libp2p-core v0.3.0/go.mod h1:ACp3DmS3/N64c2jDzcV429ukDpicbL6+TrrxANBjPGw=
 github.com/libp2p/go-libp2p-core v0.5.0/go.mod h1:49XGI+kc38oGVwqSBhDEwytaAxgZasHhFfQKibzTls0=
 github.com/libp2p/go-libp2p-core v0.8.0/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJBt/G1rVvhz5XT8=
-github.com/libp2p/go-libp2p-core v0.10.0 h1:jFy7v5Muq58GTeYkPhGzIH8Qq4BFfziqc0ixPd/pP9k=
-github.com/libp2p/go-libp2p-core v0.10.0/go.mod h1:ECdxehoYosLYHgDDFa2N4yE8Y7aQRAMf0sX9mf2sbGg=
+github.com/libp2p/go-libp2p-core v0.10.1-0.20210921170543-f829c09c1ca0 h1:W1EqIm0+QVnfQ2SV138//D9NyAhseDxqLMoWvvhYsQQ=
+github.com/libp2p/go-libp2p-core v0.10.1-0.20210921170543-f829c09c1ca0/go.mod h1:KlkHsZ0nKerWsXLZJm3LfFQwusI5k3iN4BgtYTE4IYE=
 github.com/libp2p/go-libp2p-mplex v0.4.1 h1:/pyhkP1nLwjG3OM+VuaNJkQT/Pqq73WzB3aDN3Fx1sc=
 github.com/libp2p/go-libp2p-mplex v0.4.1/go.mod h1:cmy+3GfqfM1PceHTLL7zQzAAYaryDu6iPSC+CIb094g=
 github.com/libp2p/go-libp2p-pnet v0.2.0 h1:J6htxttBipJujEjz1y0a5+eYoiPcFHhSYHH6na5f0/k=
@@ -115,8 +115,8 @@ github.com/multiformats/go-multiaddr v0.2.1/go.mod h1:s/Apk6IyxfvMjDafnhJgJ3/46z
 github.com/multiformats/go-multiaddr v0.2.2/go.mod h1:NtfXiOtHvghW9KojvtySjH5y0u0xW5UouOmQQrn6a3Y=
 github.com/multiformats/go-multiaddr v0.3.0/go.mod h1:dF9kph9wfJ+3VLAaeBqo9Of8x4fJxp6ggJGteB8HQTI=
 github.com/multiformats/go-multiaddr v0.3.1/go.mod h1:uPbspcUPd5AfaP6ql3ujFY+QWzmBD8uLLL4bXW0XfGc=
-github.com/multiformats/go-multiaddr v0.3.3 h1:vo2OTSAqnENB2rLk79pLtr+uhj+VAzSe3uef5q0lRSs=
-github.com/multiformats/go-multiaddr v0.3.3/go.mod h1:lCKNGP1EQ1eZ35Za2wlqnabm9xQkib3fyB+nZXHLag0=
+github.com/multiformats/go-multiaddr v0.4.1 h1:Pq37uLx3hsyNlTDir7FZyU8+cFCTqd5y1KiM2IzOutI=
+github.com/multiformats/go-multiaddr v0.4.1/go.mod h1:3afI9HfVW8csiF8UZqtpYRiDyew8pRX7qLIGHu9FLuM=
 github.com/multiformats/go-multiaddr-net v0.2.0/go.mod h1:gGdH3UXny6U3cKKYCvpXI5rnK7YaOIEOPVDI9tsJbEA=
 github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/gviWFaSteVbWT51qgs=
 github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=

--- a/listener.go
+++ b/listener.go
@@ -10,6 +10,7 @@ import (
 
 	logging "github.com/ipfs/go-log"
 	tec "github.com/jbenet/go-temp-err-catcher"
+	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
@@ -155,6 +156,14 @@ func (l *listener) Accept() (transport.CapableConn, error) {
 		}
 	}
 	return nil, l.err
+}
+
+func (l *listener) Multiaddr() ma.Multiaddr {
+	secProto := l.upgrader.SecurityProtocol()
+	if secProto.Code == 0 {
+		return l.Listener.Multiaddr()
+	}
+	return l.Listener.Multiaddr().Encapsulate(ma.StringCast("/" + secProto.Name))
 }
 
 func (l *listener) String() string {

--- a/listener_test.go
+++ b/listener_test.go
@@ -72,6 +72,11 @@ func TestAcceptSingleConnWithSecureTransport(t *testing.T) {
 	ln := createListener(t, upgrader)
 	defer ln.Close()
 
+	protos := ln.Multiaddr().Protocols()
+	if protos[len(protos)-1].Code != upgrader.SecurityProtocol().Code {
+		t.Fatalf("expected listener multiaddr to contain the security protocol, but got %s", ln.Multiaddr())
+	}
+
 	cconn, err := dial(t, upgrader, ln.Multiaddr(), id)
 	require.NoError(err)
 

--- a/upgrader.go
+++ b/upgrader.go
@@ -26,11 +26,15 @@ var AcceptQueueLength = 16
 
 // Upgrader is a multistream upgrader that can upgrade an underlying connection
 // to a full transport connection (secure and multiplexed).
+// The Upgrader can act in two distinct modes:
+// 1. Negotiating the security protocol using multistream: in this case, SecureMuxer must be set.
+// 2. Using the security protocol encoded in the multiaddr: in this case, SecureTransport must be set.
 type Upgrader struct {
-	PSK       ipnet.PSK
-	Secure    sec.SecureMuxer
-	Muxer     mux.Multiplexer
-	ConnGater connmgr.ConnectionGater
+	PSK             ipnet.PSK
+	SecureMuxer     sec.SecureMuxer     // only used for upgraders that handle addresses without the security protocol
+	SecureTransport sec.SecureTransport // only used for upgraders that handle addresses containing the security protocol
+	Muxer           mux.Multiplexer
+	ConnGater       connmgr.ConnectionGater
 }
 
 // UpgradeListener upgrades the passed multiaddr-net listener into a full libp2p-transport listener.
@@ -119,10 +123,21 @@ func (u *Upgrader) Upgrade(ctx context.Context, t transport.Transport, maconn ma
 }
 
 func (u *Upgrader) setupSecurity(ctx context.Context, conn net.Conn, p peer.ID, dir network.Direction) (sec.SecureConn, bool, error) {
-	if dir == network.DirInbound {
-		return u.Secure.SecureInbound(ctx, conn, p)
+	if u.SecureMuxer != nil {
+		if dir == network.DirInbound {
+			return u.SecureMuxer.SecureInbound(ctx, conn, p)
+		}
+		return u.SecureMuxer.SecureOutbound(ctx, conn, p)
 	}
-	return u.Secure.SecureOutbound(ctx, conn, p)
+
+	// When we're not using the security handshake negotiation,
+	// we've already dealt with TCP simultaneous open during the TCP handshake.
+	if dir == network.DirInbound {
+		sconn, err := u.SecureTransport.SecureInbound(ctx, conn, p)
+		return sconn, true, err
+	}
+	sconn, err := u.SecureTransport.SecureOutbound(ctx, conn, p)
+	return sconn, false, err
 }
 
 func (u *Upgrader) setupMuxer(ctx context.Context, conn net.Conn, server bool) (mux.MuxedConn, error) {

--- a/upgrader.go
+++ b/upgrader.go
@@ -13,7 +13,9 @@ import (
 	ipnet "github.com/libp2p/go-libp2p-core/pnet"
 	"github.com/libp2p/go-libp2p-core/sec"
 	"github.com/libp2p/go-libp2p-core/transport"
+
 	pnet "github.com/libp2p/go-libp2p-pnet"
+	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
@@ -51,6 +53,17 @@ func (u *Upgrader) UpgradeListener(t transport.Transport, list manet.Listener) t
 	}
 	go l.handleIncoming()
 	return l
+}
+
+// SecurityProtocol return the security protocol that this upgrader uses.
+// Note that this function only makes sense when not using a SecureMuxer.
+// If a SecureMuxer is used, the zero value of ma.Protocol is returned.
+func (u *Upgrader) SecurityProtocol() ma.Protocol {
+	if u.SecureMuxer != nil {
+		var zero ma.Protocol
+		return zero
+	}
+	return u.SecureTransport.Protocol()
 }
 
 // UpgradeOutbound upgrades the given outbound multiaddr-net connection into a


### PR DESCRIPTION
This PR makes changes to the upgrader, so we can use it to handle both multiaddrs with and without the security protocol.
Depends on https://github.com/libp2p/go-libp2p-core/pull/215.

For multiaddrs not containing the security protocol:
* `Upgrader.SecureMuxer` needs to be set (this is the same as it is now). The upgrader will then use multistream to negotiate the security protocol.

For multiaddrs containing the security protocol:
* `Upgrader.SecureTransport` needs to be set (and `Upgrader.SecureMuxer` must not be set). In that case, the upgrader will jump into the cryptographic handshake right after having dialed / accepted the `net.Conn`.

This PR also adds a `Upgrader.SecurityProtocol() ma.Protocol` method, which returns the security protocol of the `SecureTransport`. Perhaps a bit surprisingly, this returns the zero-value of `ma.Protocol` in case a `SecureMuxer` is set. We _could_ have introduced a `valid bool` here, but I chose not to do so, as we'll be dropping support for the `SecureMuxer` soon-ish, and having just a single return value will be nicer then.