### PR TITLE
reset the temporary error catcher delay after successful accept

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -80,6 +80,7 @@ func (l *listener) handleIncoming() {
 			l.err = err
 			return
 		}
+		catcher.Reset()
 
 		// gate the connection if applicable
 		if l.upgrader.ConnGater != nil && !l.upgrader.ConnGater.InterceptAccept(maconn) {


### PR DESCRIPTION
I'm not sure we need the temporary error catcher in the first place (why would `Accept` return a temporary error? At least for QUIC, it never does), but if we're using it, we should reset it after successfully accepting a connection (see documentation of `catcher.IsTemporary`).