### PR TITLE
make the accept timeout configurable, stop using transport.AcceptTimeout

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -105,7 +105,7 @@ func (l *listener) handleIncoming() {
 		go func() {
 			defer wg.Done()
 
-			ctx, cancel := context.WithTimeout(l.ctx, transport.AcceptTimeout)
+			ctx, cancel := context.WithTimeout(l.ctx, l.upgrader.acceptTimeout())
 			defer cancel()
 
 			conn, err := l.upgrader.Upgrade(ctx, l.transport, maconn, network.DirInbound, "")

--- a/listener_test.go
+++ b/listener_test.go
@@ -21,10 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func init() {
-	transport.AcceptTimeout = 1 * time.Hour
-}
-
 type MuxAdapter struct {
 	tpt sec.SecureTransport
 }
@@ -100,11 +96,9 @@ func TestConnectionsClosedIfNotAccepted(t *testing.T) {
 	if os.Getenv("CI") != "" {
 		timeout = 500 * time.Millisecond
 	}
-	origAcceptTimeout := transport.AcceptTimeout
-	transport.AcceptTimeout = timeout
-	t.Cleanup(func() { transport.AcceptTimeout = origAcceptTimeout })
 
 	id, upgrader := createUpgrader(t)
+	upgrader.AcceptTimeout = timeout
 	ln := createListener(t, upgrader)
 	defer ln.Close()
 


### PR DESCRIPTION
This is the analogous change to https://github.com/libp2p/go-libp2p-swarm/pull/302. Motivation: stop relying on global variables (and make dial and accept timeouts consistent).

The nicer way to configure this would be by having an option. Unfortunately, that's not possible as we don't have a constructor here.
We could refactor the code by introducing an `Upgrader` interface, and then unexporting the `Upgrader` here, while at the same time introducing a constructor.